### PR TITLE
CXC-399-Multiple-selection-Mobile

### DIFF
--- a/components/WrapperCanvas.vue
+++ b/components/WrapperCanvas.vue
@@ -20,9 +20,17 @@
     const panelBorder = ref(`url(${props.panel.border})`);
     const currentHeight = ref(1);
     const currentWidth = ref(1);
+    const activeElementId = ref(null);
+    const isDragging = ref(false);
     let resizing = ref(false);
 
     let resizeTimeout;
+
+    function setActiveElement(eId) {
+        if (!isDragging.value) {
+            activeElementId.value = eId;
+        }
+    }
 
     function setToRelative(num, panelNum) {
         return num / panelNum;
@@ -187,6 +195,7 @@
                     :selectedId="props.selectedId"
                     :lockAspectRatio="props.lockAspectRatio"
                     :element="value"
+                    :active="activeElementId == value.id"
                     @delete-event="deleteElement"
                     @update-event="updatePosition"
                     @resize-event="resizeElement"
@@ -195,6 +204,9 @@
                     @rotate-event="updateRotation"
                     @front-event="upElement"
                     @back-event="downElement"
+                    @dragging="isDragging = true"
+                    @dragstop="isDragging = false"
+                    @activated="setActiveElement(value.id)"
                 />
             </div>
         </div>


### PR DESCRIPTION
Added an extra handling of the active status to the Parent of the DragResizeRotate - the WrapperCanvas: added a flag to check if the element is being dragged and not allowing the activation during that.
This prevents the drag operation from being recognized as a click and setting the active status on two elements.

It's deployed here, so it can be tested on mobile:
[Deployed Branch](https://cxc-399-multiple-selection-mobile--cxc-399.netlify.app/editor)

