### PR TITLE
Cxc 387 keep handles and edition menu on top

### DIFF
--- a/components/DragResizeRotate.vue
+++ b/components/DragResizeRotate.vue
@@ -201,6 +201,7 @@
         </div>
 
         <img
+            class="element__image"
             :src="url"
             :alt="altText"
             :class="{ mirror: mirroredHorizontal || mirroredVertical }"
@@ -210,13 +211,20 @@
 </template>
 
 <style lang="scss" scoped>
-    img {
-        width: 100%;
-        height: 100%;
-    }
+    .element {
+        &--active {
+            border: $border-width solid $info;
+            z-index: 10000 !important;
 
-    .element--active {
-        border: $border-width solid $info;
+            .element__image {
+                opacity: 0.5;
+            }
+        }
+
+        &__image {
+            width: 100%;
+            height: 100%;
+        }
     }
 
     .edition-menu {

--- a/components/DragResizeRotate.vue
+++ b/components/DragResizeRotate.vue
@@ -216,7 +216,8 @@
             border: $border-width solid $info;
             z-index: 10000 !important;
 
-            .element__image {
+            .element__image,
+            .text__content {
                 opacity: 0.5;
             }
         }


### PR DESCRIPTION
I implemented the moving in front as we discussed.
- Move complete element to the front
- set the opacity of he image and text to 50%

The `:not`-operator was not a feasible solution that would work on this problem.

There was no problem with any glitches when changing layers.
Please verify that the layer changing and actions still work as expected.