### PR TITLE
Cxc 389 panel navigation mobile

### DIFF
--- a/assets/scss/_swipper.scss
+++ b/assets/scss/_swipper.scss
@@ -18,7 +18,9 @@
         justify-content: center;
         align-items: center;
         opacity: 1;
-        border-radius: 50%;
+        border-radius: 4px;
+        width: 24px;
+        height: 33px;
         background-color: $secondary-50;
 
         @include media-breakpoint-up(lg) {

--- a/assets/scss/_swipper.scss
+++ b/assets/scss/_swipper.scss
@@ -18,7 +18,7 @@
         justify-content: center;
         align-items: center;
         opacity: 1;
-        border-radius: 4px;
+        border-radius: $border-radius;
         width: 24px;
         height: 33px;
         background-color: $secondary-50;


### PR DESCRIPTION
The bullet navigation points are now in form of small panels. It was checked with Alica.
Their width is 24px. (the minimum size for mobile)