### PR TITLE
CXC-422: text resizing button hidden

### DIFF
--- a/components/TextEditor.vue
+++ b/components/TextEditor.vue
@@ -70,9 +70,9 @@
         ></textarea>
 
         <div class="font-size" @click.stop="true">
-            <button class="font-size__button" @click="decreaseFont">-</button>
-            <p class="font-size__text p5">{{ fontSize }}</p>
             <button class="font-size__button" @click="increaseFont">+</button>
+            <p class="font-size__text p5">{{ fontSize }}</p>
+            <button class="font-size__button" @click="decreaseFont">-</button>
         </div>
     </div>
 </template>

--- a/components/TextEditor.vue
+++ b/components/TextEditor.vue
@@ -102,6 +102,7 @@
             grid-template-rows: repeat(3, auto);
             border: $border-width $black solid;
             border-radius: $border-radius;
+            user-select: none;
 
             &__button {
                 background: none;

--- a/components/TextEditor.vue
+++ b/components/TextEditor.vue
@@ -108,6 +108,7 @@
                 border: none;
                 padding: $spacer-2 $spacer-3;
                 cursor: pointer;
+                color: $black;
 
                 &:hover {
                     background-color: $grey-40;

--- a/components/TextEditor.vue
+++ b/components/TextEditor.vue
@@ -62,7 +62,6 @@
         <textarea
             class="text-editor__textarea"
             tabindex="0"
-            rows="4"
             ref="textarea"
             :style="{ fontSize: fontSize + 'px' }"
             v-model="textValue"
@@ -72,7 +71,7 @@
 
         <div class="font-size" @click.stop="true">
             <button class="font-size__button" @click="decreaseFont">-</button>
-            <p class="font-size__text">{{ fontSize }}px</p>
+            <p class="font-size__text p5">{{ fontSize }}</p>
             <button class="font-size__button" @click="increaseFont">+</button>
         </div>
     </div>
@@ -85,24 +84,24 @@
         top: 0;
         width: 100%;
         height: 100%;
-        display: grid;
-        justify-items: center;
+        display: flex;
+        justify-content: center;
         align-items: center;
-        z-index: 100;
-        background-color: rgba(112, 112, 112, 0.5);
+        gap: $spacer-3;
+        z-index: 1;
+        background-color: rgba($medium-grey-100, 0.5);
 
         &__textarea {
-            max-width: 80%;
+            width: calc(80% - $spacer-7);
+            height: 40svh;
         }
 
         .font-size {
             background-color: $white;
             display: grid;
-            align-self: end;
-            grid-template-columns: repeat(3, auto);
+            grid-template-rows: repeat(3, auto);
             border: $border-width $black solid;
             border-radius: $border-radius;
-            margin-bottom: $spacer-2;
 
             &__button {
                 background: none;


### PR DESCRIPTION
I moved the text resizing button next to the input field. I made the input field to a fixed width (still responsive to the device you are on though). I also moved the + and  - button around as stated in the task-description.