### PR TITLE
Cxc 408 inconsistency in text size

### DIFF
--- a/components/DragResizeRotate.vue
+++ b/components/DragResizeRotate.vue
@@ -200,7 +200,10 @@
             @dblclick="comicStore.setCurrentElement(props.element)"
             @touchstart="detectDoubleClick"
         >
-            <p class="text__content" :style="{ fontSize: fontSize + 'px' }">
+            <p
+                class="text__content"
+                :style="{ fontSize: Math.round(fontSize * comicStore.getCurrentCanvas().width) + 'px' }"
+            >
                 {{ text }}
             </p>
         </div>

--- a/components/DragResizeRotate.vue
+++ b/components/DragResizeRotate.vue
@@ -274,7 +274,6 @@
             width: 100%;
             height: 100%;
             font-family: 'Pangolin';
-            word-break: break-word;
         }
     }
 </style>

--- a/components/PreviewCanvas.vue
+++ b/components/PreviewCanvas.vue
@@ -201,8 +201,9 @@
             // Save the current context
             context.save();
 
+            let fontSize = element.type.fontSize * panelDimension.width;
             // Set the font properties
-            context.font = `${element.type.fontSize}px ${element.type.fontFamily}`;
+            context.font = `${fontSize}px ${element.type.fontFamily}`;
             context.fillStyle = 'black';
             context.textBaseline = 'top';
 
@@ -232,7 +233,7 @@
             // Draw the text once the lines are created
             new Promise((resolveLine) => {
                 getLines(context, element.type.content, element.width * panelDimension.width).forEach((line, i) => {
-                    context.fillText(line, 0, i * element.type.fontSize);
+                    context.fillText(line, 0, i * fontSize);
                 });
                 context.restore();
                 resolveLine('line drawn');
@@ -244,17 +245,22 @@
     function getLines(context, text, maxWidth) {
         let words = text.split(' ');
         let lines = [];
-        let currentLine = words[0];
+        let currentLine = '';
 
         // Loop through each word and add it to the current line if it fits
-        for (let i = 1; i < words.length; i++) {
+        for (let i = 0; i < words.length; i++) {
             let word = words[i];
-            let width = context.measureText(currentLine + ' ' + word).width;
+            let width = context.measureText(currentLine + word + ' ').width;
             if (width < maxWidth) {
-                currentLine += ' ' + word;
+                currentLine += word + ' ';
+            } else if (word.includes('-') && width > maxWidth) {
+                const splitWord = word.split('-');
+                currentLine += splitWord[0] + '-';
+                lines.push(currentLine);
+                currentLine = splitWord[1] + ' ';
             } else {
                 lines.push(currentLine);
-                currentLine = word;
+                currentLine = word + ' ';
             }
         }
         lines.push(currentLine);

--- a/components/TextEditor.vue
+++ b/components/TextEditor.vue
@@ -9,6 +9,7 @@
 
     // Static Variables (let, const)
     const accumulatedChanges = ref({});
+    const canvasWidth = ref(0);
     const comicStore = useComicStore();
     const textarea = ref(null);
     const textValue = ref('');
@@ -39,15 +40,14 @@
             id: element.value.id,
             text: changes.text || textValue.value,
             fontSize:
-                changes.fontSize / comicStore.getCurrentCanvas().width ||
-                fontSize.value / comicStore.getCurrentCanvas().width,
+                getRelative(changes.fontSize, canvasWidth.value) || getRelative(fontSize.value, canvasWidth.value),
         });
         accumulatedChanges.value = {};
     }
 
     function decreaseFont() {
         fontSize.value -= 1;
-        element.value.type.fontSize = getRelative(fontSize.value, comicStore.getCurrentCanvas().width);
+        element.value.type.fontSize = getRelative(fontSize.value, canvasWidth.value);
         accumulatedChanges.value.fontSize = fontSize.value;
     }
 
@@ -61,7 +61,7 @@
 
     function increaseFont() {
         fontSize.value += 1;
-        element.value.type.fontSize = getRelative(fontSize.value, comicStore.getCurrentCanvas().width);
+        element.value.type.fontSize = getRelative(fontSize.value, canvasWidth.value);
         accumulatedChanges.value.fontSize = fontSize.value;
     }
 
@@ -69,7 +69,7 @@
         element.value = comicStore.getCurrentElement().value;
         textarea.value.focus();
         textValue.value = element.value.type.content;
-        fontSize.value = Math.round(element.value.type.fontSize * comicStore.getCurrentCanvas().width);
+        fontSize.value = getFixed(element.value.type.fontSize, canvasWidth.value);
     }
 
     function stopModifyText() {
@@ -83,6 +83,7 @@
 
     // Vue life cycle hooks
     onMounted(() => {
+        canvasWidth.value = comicStore.getCurrentCanvas().width;
         startModifyText();
     });
 

--- a/components/TextEditor.vue
+++ b/components/TextEditor.vue
@@ -1,29 +1,28 @@
 <script setup>
+    // Imports
+
+    // Middlewares
+
+    // Emits
+
+    // Props
+
+    // Static Variables (let, const)
+    const accumulatedChanges = ref({});
+    const comicStore = useComicStore();
     const textarea = ref(null);
     const textValue = ref('');
-    const comicStore = useComicStore();
-    let fontSize = ref(24);
     let element = ref(null);
+    let fontSize = ref(24);
 
-    const accumulatedChanges = ref({});
+    // Reactive Variables
+    // computed
 
-    function startModifyText() {
-        element.value = comicStore.getCurrentElement().value;
-        textarea.value.focus();
-        textValue.value = element.value.type.content;
-        fontSize.value = element.value.type.fontSize;
-    }
+    // Reactive
 
-    function applyAccumulatedChanges() {
-        const changes = accumulatedChanges.value;
-        comicStore.bus.emit('updateText', {
-            id: element.value.id,
-            text: changes.text || textValue.value,
-            fontSize: changes.fontSize || fontSize.value,
-        });
-        accumulatedChanges.value = {};
-    }
+    // Refs
 
+    // Watchers
     watch(
         [textValue, fontSize],
         ([newTextValue, newFontSize]) => {
@@ -33,6 +32,46 @@
         { deep: true }
     );
 
+    // Methods
+    function applyAccumulatedChanges() {
+        const changes = accumulatedChanges.value;
+        comicStore.bus.emit('updateText', {
+            id: element.value.id,
+            text: changes.text || textValue.value,
+            fontSize:
+                changes.fontSize / comicStore.getCurrentCanvas().width ||
+                fontSize.value / comicStore.getCurrentCanvas().width,
+        });
+        accumulatedChanges.value = {};
+    }
+
+    function decreaseFont() {
+        fontSize.value -= 1;
+        element.value.type.fontSize = getRelative(fontSize.value, comicStore.getCurrentCanvas().width);
+        accumulatedChanges.value.fontSize = fontSize.value;
+    }
+
+    function getFixed(num, panelNum) {
+        return num * panelNum;
+    }
+
+    function getRelative(num, panelNum) {
+        return num / panelNum;
+    }
+
+    function increaseFont() {
+        fontSize.value += 1;
+        element.value.type.fontSize = getRelative(fontSize.value, comicStore.getCurrentCanvas().width);
+        accumulatedChanges.value.fontSize = fontSize.value;
+    }
+
+    function startModifyText() {
+        element.value = comicStore.getCurrentElement().value;
+        textarea.value.focus();
+        textValue.value = element.value.type.content;
+        fontSize.value = Math.round(element.value.type.fontSize * comicStore.getCurrentCanvas().width);
+    }
+
     function stopModifyText() {
         element.value.type.content = textValue.value;
         applyAccumulatedChanges();
@@ -40,21 +79,14 @@
         comicStore.setCurrentElement(null);
     }
 
-    function increaseFont() {
-        element.value.type.increaseFontSize();
-        fontSize.value = element.value.type.fontSize;
-        accumulatedChanges.value.fontSize = fontSize.value;
-    }
+    // Bus Listeners
 
-    function decreaseFont() {
-        element.value.type.decreaseFontSize();
-        fontSize.value = element.value.type.fontSize;
-        accumulatedChanges.value.fontSize = fontSize.value;
-    }
-
+    // Vue life cycle hooks
     onMounted(() => {
         startModifyText();
     });
+
+    // expose (defineExpose)
 </script>
 
 <template>

--- a/components/WrapperCanvas.vue
+++ b/components/WrapperCanvas.vue
@@ -141,7 +141,7 @@
             const height = setToRelative(200, currentHeight.value);
             const width = setToRelative(200, currentWidth.value);
             let name = 'Double-click to edit me.';
-            let type = new Text(name, 0.05, 'Pangolin');
+            let type = new Text(name, 0.03206997084548105, 'Pangolin');
             tempEl = new ElementDS(width, height, name, type);
         }
         props.panel.addElement(tempEl);

--- a/components/WrapperCanvas.vue
+++ b/components/WrapperCanvas.vue
@@ -141,7 +141,7 @@
             const height = setToRelative(200, currentHeight.value);
             const width = setToRelative(200, currentWidth.value);
             let name = 'Double-click to edit me.';
-            let type = new Text(name, 0.03206997084548105, 'Pangolin');
+            let type = new Text(name, setToRelative(24, currentWidth.value), 'Pangolin');
             tempEl = new ElementDS(width, height, name, type);
         }
         props.panel.addElement(tempEl);

--- a/components/WrapperCanvas.vue
+++ b/components/WrapperCanvas.vue
@@ -46,6 +46,10 @@
             wrapperCanvas.value.clientWidth / wrapperCanvas.value.clientHeight > aspectRatioWidth / aspectRatioHeight;
         currentWidth.value = panelElement.value.clientWidth;
         currentHeight.value = panelElement.value.clientHeight;
+        comicStore.setCurrentCanvas({
+            width: currentWidth.value,
+            height: currentHeight.value,
+        });
     }
 
     function deleteElement(eId) {
@@ -137,7 +141,7 @@
             const height = setToRelative(200, currentHeight.value);
             const width = setToRelative(200, currentWidth.value);
             let name = 'Double-click to edit me.';
-            let type = new Text(name, 24, 'Pangolin');
+            let type = new Text(name, 0.05, 'Pangolin');
             tempEl = new ElementDS(width, height, name, type);
         }
         props.panel.addElement(tempEl);

--- a/stores/useComicStore.js
+++ b/stores/useComicStore.js
@@ -13,6 +13,7 @@ export const useComicStore = defineStore('comic', () => {
     let comic = new Comic(null, null, null);
     let currentElement = ref(null);
     let bus = mitt();
+    let currentCanvas = ref({});
 
     const draft = ref(null);
 
@@ -50,6 +51,14 @@ export const useComicStore = defineStore('comic', () => {
 
     function getCurrentElement() {
         return currentElement;
+    }
+
+    function setCurrentCanvas(canvas) {
+        currentCanvas.value = canvas;
+    }
+
+    function getCurrentCanvas() {
+        return currentCanvas.value;
     }
 
     /**
@@ -146,5 +155,7 @@ export const useComicStore = defineStore('comic', () => {
         createComicFromDraft,
         setCurrentElement,
         getCurrentElement,
+        setCurrentCanvas,
+        getCurrentCanvas,
     };
 });

--- a/test-procedure-guideline.md
+++ b/test-procedure-guideline.md
@@ -18,6 +18,8 @@ Here are a few step that you should follow:
    - Do a search with the catalog
    - Filter results
    - delete an asset
+   - undo an action
+   - redo an action
 4. Add an asset without modification
 5. move some asset up and down using the buttons
 6. move some asset up and down using the layers popup

--- a/utils/Classes/Text.js
+++ b/utils/Classes/Text.js
@@ -19,7 +19,7 @@ export default class Text {
      */
     constructor(content = null, fontSize = null, fontFamily = null) {
         this._content = content ?? 'undefined';
-        this._fontSize = fontSize ?? 0.05;
+        this._fontSize = fontSize ?? 0.03206997084548105;
         this._fontFamily = fontFamily ?? 'Nunito';
     }
 

--- a/utils/Classes/Text.js
+++ b/utils/Classes/Text.js
@@ -19,7 +19,7 @@ export default class Text {
      */
     constructor(content = null, fontSize = null, fontFamily = null) {
         this._content = content ?? 'undefined';
-        this._fontSize = fontSize ?? 16;
+        this._fontSize = fontSize ?? 0.05;
         this._fontFamily = fontFamily ?? 'Nunito';
     }
 

--- a/utils/Classes/Text.js
+++ b/utils/Classes/Text.js
@@ -19,7 +19,7 @@ export default class Text {
      */
     constructor(content = null, fontSize = null, fontFamily = null) {
         this._content = content ?? 'undefined';
-        this._fontSize = fontSize ?? 0.03206997084548105;
+        this._fontSize = fontSize ?? 0.05;
         this._fontFamily = fontFamily ?? 'Nunito';
     }
 


### PR DESCRIPTION
The task was asking to save the fontSize value into the text.js in pixels. I decided to save the relative value since:
1. it makes more sense
2. save the pixel value relative to the exported canvas size would have needed far more modifications in the code.

I changed the word-break property on the editor. until now everything was done so that the text fits into the container, but this is not how the text is printed on the canvas => now both have the same behavior and what the user sees on the editor is printed on the preview.

I also refactored textEditor, mainly because i couldn't find what I was looking for, and it helped me see more clearly.

**I had shortly a bug on safari on Iphone: the value of the fontsize was with decimals.
It happened 1 time and I couldn't reproduce it since then...**
