### PR TITLE
Cxc 412 catalog title font size

### DIFF
--- a/components/CatalogLayout.vue
+++ b/components/CatalogLayout.vue
@@ -116,4 +116,15 @@
             padding: $spacer-2;
         }
     }
+    @include media-breakpoint-up(md) {
+        .catalog {
+            padding-top: 3rem;
+        }
+    }
+
+    @include media-breakpoint-up(lg) {
+        .catalog {
+            padding-top: 0;
+        }
+    }
 </style>

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -421,6 +421,7 @@
         width: 100%;
         background-color: $white;
         z-index: 2;
+        align-items: center;
     }
     .catalog-overlay-content {
         height: 87svh;
@@ -432,5 +433,11 @@
     }
     .top-nav__item-redo-btn {
         color: $grey-0;
+    }
+
+    @include media-breakpoint-up(md) {
+        .edit-icon {
+            font-size: 40px;
+        }
     }
 </style>


### PR DESCRIPTION
The heading of catalogue on tablet is fixed - it looks normal and it's possible to read. Also the size of the icon is adjusted. Deployed on: https://cxc-412.netlify.app/