### PR TITLE
CXC-416: can't select category after closing it

### DIFF
--- a/components/CatalogLayout.vue
+++ b/components/CatalogLayout.vue
@@ -23,16 +23,6 @@
         () => props.selectedCategory,
         () => {
             selectedSubCategory.value = {};
-            // Reset selected filters when category changes
-            selectedFilter.value = [];
-            emitCatalogChanged();
-        }
-    );
-
-    // Watch for changes in selectedSubCategory
-    watch(
-        () => selectedSubCategory.value,
-        () => {
             selectedFilter.value = [];
             emitCatalogChanged();
         }
@@ -51,6 +41,7 @@
             selectedSubCategory.value = {};
         } else {
             selectedSubCategory.value = subCategory;
+            selectedFilter.value = [];
         }
         emitCatalogChanged();
     }

--- a/components/CatalogLayout.vue
+++ b/components/CatalogLayout.vue
@@ -104,7 +104,7 @@
         }
 
         &__container {
-            padding: $spacer-2;
+            padding: 0 $spacer-2 $spacer-2 $spacer-2;
         }
     }
     @include media-breakpoint-up(md) {

--- a/components/CatalogLayout.vue
+++ b/components/CatalogLayout.vue
@@ -41,8 +41,8 @@
             selectedSubCategory.value = {};
         } else {
             selectedSubCategory.value = subCategory;
-            selectedFilter.value = [];
         }
+        selectedFilter.value = [];
         emitCatalogChanged();
     }
 

--- a/components/CatalogNavigation.vue
+++ b/components/CatalogNavigation.vue
@@ -16,10 +16,8 @@
     selectedCategory.value = props.allAssetsButtonName;
 
     function selectCategory(category) {
-        if (selectedCategory.value !== category.name) {
-            selectedCategory.value = category.name; // Select category
-            emit('categorySelected', category, []);
-        }
+        selectedCategory.value = category.name;
+        emit('categorySelected', category, []);
     }
 
     function selectAllAssets() {

--- a/components/CatalogNavigation.vue
+++ b/components/CatalogNavigation.vue
@@ -87,6 +87,9 @@
         }
 
         .navigation button {
+            text-overflow: ellipsis;
+            overflow: hidden;
+
             &.selected {
                 background-color: $secondary;
                 color: $white;

--- a/components/CatalogNavigation.vue
+++ b/components/CatalogNavigation.vue
@@ -9,7 +9,7 @@
         allAssetsButtonName: { type: String, default: 'All Assets' },
     });
 
-    const emit = defineEmits(['categorySelected', 'selectAllAssets']);
+    const emit = defineEmits(['categorySelected']);
     const comicStore = useComicStore();
 
     // Initialize selectedCategory with allAssetsButtonName by default
@@ -23,8 +23,10 @@
     }
 
     function selectAllAssets() {
-        selectedCategory.value = props.allAssetsButtonName; // Select "All Assets" button
-        emit('selectAllAssets');
+        selectCategory({
+            name: props.allAssetsButtonName,
+            subCategories: [],
+        });
     }
 
     // Functionality to add new text to display

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -65,14 +65,6 @@
         selectedCategory.value = category;
         catalogShow.value = true;
     }
-    function handleSelectAllAssets() {
-        selectedCategory.value = {
-            name: allAssetsCategoryName,
-            subCategories: [],
-        };
-        catalogShow.value = true;
-        fetchCatalogElements([], [], []);
-    }
 
     function selectElement(eId) {
         selectedElementId.value = eId;
@@ -139,10 +131,6 @@
         { deep: true }
     );
 
-    onMounted(() => {
-        fetchCatalogElements();
-    });
-
     onBeforeUnmount(() => {
         window.onkeydown = null;
         window.onkeyup = null;
@@ -206,7 +194,6 @@
                 <CatalogNavigation
                     :categories="catalogStructure.categories"
                     @categorySelected="updateSelectedCategory"
-                    @selectAllAssets="handleSelectAllAssets"
                 />
             </div>
             <div class="catalog-container col-lg-2 col-xl-3 order-lg-first">

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -6,7 +6,6 @@
     let previewShow = ref(false);
     let catalogShow = ref(false);
     let goingBackPopUpShow = ref(false);
-    let selectedElementId = ref(null);
     let lockAspectRatio = ref(false);
     let editor = ref(null);
     let userDidSomething = ref(false);
@@ -64,10 +63,6 @@
     function updateSelectedCategory(category) {
         selectedCategory.value = category;
         catalogShow.value = true;
-    }
-
-    function selectElement(eId) {
-        selectedElementId.value = eId;
     }
 
     function saveComic() {
@@ -242,11 +237,7 @@
     <ScreenOverlay title="Layers" :show="layersShow" @close="layersShow = false">
         <div class="layer-background">
             <div class="layer-container">
-                <LayerObject
-                    :panel="comic.getPage(0).getStrip(0).getPanel(activePanelIndex)"
-                    @selection-event="selectElement"
-                >
-                </LayerObject>
+                <LayerObject :panel="comic.getPage(0).getStrip(0).getPanel(activePanelIndex)"> </LayerObject>
             </div>
         </div>
     </ScreenOverlay>


### PR DESCRIPTION
Now you are able to select a category right after each other.

Because I was confused with some of the logic I simplified it a bit and also removed a repeated call to the API.
⚠️ Please carefully check the complete catalog behavior: category, sub-category, search, filter. if everything is still working well. On mobile and on desktop.