### PR TITLE
fix pop-up not showing on export

### DIFF
--- a/pages/export.vue
+++ b/pages/export.vue
@@ -24,9 +24,6 @@
     let disableButton = ref(true);
 
     // Watchers
-    window.onbeforeunload = function (e) {
-        e.preventDefault();
-    };
 
     // Methods
     function download() {
@@ -63,6 +60,14 @@
     // Bus Listeners
 
     // Vue life cycle hooks
+    onMounted(() => {
+        window.onbeforeunload = function (e) {
+            if (e.target.activeElement === this.document.body) {
+                e.preventDefault();
+            }
+        };
+    });
+
     onBeforeUnmount(() => {
         window.onbeforeunload = null;
     });


### PR DESCRIPTION
Tested on mac > Chrome and Safari.

Important things:

- In Editor.vue, if the user does nothing, you can reaload and go back (with our back arrow btn) without pop-up.
- In editor.vue, if the user do any action (adding asset, transforn asset...) that impact the canvas, then a pop-up should show on going back AND on reload browser.
- In export, the browser pop-up should show on reload but not on going back arrow btn