### PR TITLE
CXC-423 check zindex of buttons

### DIFF
--- a/components/ScreenOverlay.vue
+++ b/components/ScreenOverlay.vue
@@ -26,6 +26,7 @@
         align-items: center;
         justify-content: space-between;
         color: $white;
+        z-index: 99999;
     }
 
     .icon-btn {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -252,6 +252,7 @@
     .accent-btn {
         bottom: $spacer-6;
         transform: translateX(5%);
+        z-index: 99999;
     }
 
     .draft-container {


### PR DESCRIPTION
Added z index of 9999 to ScreenOverlay and index page for the buttons

Please check if the delete draft button overlaps the main button (resume comic crafting), and if the chevrons go over the top nav in the layer management. both should be fixed now.