### PR TITLE
CXC-431: change element size on add

### DIFF
--- a/components/WrapperCanvas.vue
+++ b/components/WrapperCanvas.vue
@@ -123,11 +123,13 @@
     comicStore.bus.on('add-element', (event) => {
         if (!props.panelIsActive) return;
 
-        let tempEl;
+        let elementType = null;
+        let height = 0;
+        let width = 0;
+        let name = '';
+
         if (event) {
-            let height = 0;
-            let width = 0;
-            let percentageFill = 0.2;
+            let percentageFill = 0.3;
 
             if (event.target.naturalWidth < event.target.naturalHeight) {
                 width = percentageFill;
@@ -151,7 +153,7 @@
                 }
             } else {
                 height = percentageFill;
-                width = width = calculateRelativeLengthB(
+                width = calculateRelativeLengthB(
                     height,
                     event.target.naturalHeight,
                     currentHeight.value,
@@ -171,18 +173,15 @@
                 }
             }
 
-            let name = event.target.alt;
-            let src = event.target.src;
-            let newAsset = new Asset(src);
-            tempEl = new ElementDS(width, height, name, newAsset);
+            name = event.target.alt;
+            elementType = new Asset(event.target.src);
         } else {
-            const height = setToRelative(200, currentHeight.value);
-            const width = setToRelative(200, currentWidth.value);
-            let name = 'Double-click to edit me.';
-            let type = new Text(name, 24, 'Pangolin');
-            tempEl = new ElementDS(width, height, name, type);
+            height = setToRelative(200, currentHeight.value);
+            width = setToRelative(200, currentWidth.value);
+            name = 'Double-click to edit me.';
+            elementType = new Text(name, 24, 'Pangolin');
         }
-        props.panel.addElement(tempEl);
+        props.panel.addElement(new ElementDS(width, height, name, elementType));
     });
 
     // functions

--- a/components/WrapperCanvas.vue
+++ b/components/WrapperCanvas.vue
@@ -41,6 +41,19 @@
         return num * panelNum;
     }
 
+    function calculateRelativeLengthB(
+        relativeLengthA,
+        naturalLengthA,
+        maxAbsoluteLengthA,
+        naturalLengthB,
+        maxAbsoluteLengthB
+    ) {
+        return setToRelative(
+            (getFixed(relativeLengthA, maxAbsoluteLengthA) * naturalLengthB) / naturalLengthA,
+            maxAbsoluteLengthB
+        );
+    }
+
     function updatePanelBoundingBox() {
         scaleByHeight.value =
             wrapperCanvas.value.clientWidth / wrapperCanvas.value.clientHeight > aspectRatioWidth / aspectRatioHeight;
@@ -114,19 +127,48 @@
         if (event) {
             let height = 0;
             let width = 0;
+            let percentageFill = 0.2;
 
-            if (event.target.naturalWidth > event.target.naturalHeight) {
-                width = 0.2;
-                height = setToRelative(
-                    (getFixed(width, currentWidth.value) * event.target.naturalHeight) / event.target.naturalWidth,
+            if (event.target.naturalWidth < event.target.naturalHeight) {
+                width = percentageFill;
+                height = calculateRelativeLengthB(
+                    width,
+                    event.target.naturalWidth,
+                    currentWidth.value,
+                    event.target.naturalHeight,
                     currentHeight.value
                 );
+
+                if (height > 1) {
+                    height = 1;
+                    width = calculateRelativeLengthB(
+                        height,
+                        event.target.naturalHeight,
+                        currentHeight.value,
+                        event.target.naturalWidth,
+                        currentWidth.value
+                    );
+                }
             } else {
-                height = 0.2;
-                width = setToRelative(
-                    (getFixed(height, currentHeight.value) * event.target.naturalWidth) / event.target.naturalHeight,
+                height = percentageFill;
+                width = width = calculateRelativeLengthB(
+                    height,
+                    event.target.naturalHeight,
+                    currentHeight.value,
+                    event.target.naturalWidth,
                     currentWidth.value
                 );
+
+                if (width > 1) {
+                    width = 1;
+                    height = calculateRelativeLengthB(
+                        width,
+                        event.target.naturalWidth,
+                        currentWidth.value,
+                        event.target.naturalHeight,
+                        currentHeight.value
+                    );
+                }
             }
 
             let name = event.target.alt;


### PR DESCRIPTION
I adjusted how the size of the element is determined when it is placed down.

1. It is determined what the shortest side of an asset is
2. The shortest side of an asset is set to 30% of it's maximum size (height or width)
3. The other axis size is calculated in proportion
4. If the second axis is larger than 100% of it's maximum value. It is set to 100% and the first axis size is recalculated based on that.

Please verify that these sizes are working and that with these default configurations the majority of assets is usable after inserting.