### PR TITLE
CXC-414: layers and preview are larger than one screen height

### DIFF
--- a/assets/scss/_navigation.scss
+++ b/assets/scss/_navigation.scss
@@ -3,6 +3,6 @@
     align-items: center;
     background: linear-gradient(90deg, #6360f4 44.5%, #f460b7 100%);
     margin: 0;
-    height: 3.5rem;
+    height: $nav-bar-height;
     padding: 0 $spacer-3;
 }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -170,6 +170,8 @@ $border-width-lg: 2px;
 $box-shadow-top-right: 3px -3px 2px $grey-30;
 $box-shadow-right: 3px 0px 2px $grey-30;
 
+$nav-bar-height: 3.5rem;
+
 @import '~bootstrap/scss/functions';
 @import '~bootstrap/scss/mixins';
 @import '~bootstrap/scss/variables';

--- a/components/ScreenOverlay.vue
+++ b/components/ScreenOverlay.vue
@@ -46,7 +46,7 @@
     }
 
     .overlay__content {
-        height: calc(100dvh - 3.5rem);
+        height: calc(100dvh - $nav-bar-height);
         width: 100vw;
     }
 </style>

--- a/components/ScreenOverlay.vue
+++ b/components/ScreenOverlay.vue
@@ -37,8 +37,6 @@
     }
 
     .overlay {
-        height: 100dvh;
-        width: 100vw;
         position: fixed;
         z-index: 999999;
         top: 0;
@@ -48,7 +46,7 @@
     }
 
     .overlay__content {
-        width: 100%;
-        height: 100%;
+        height: calc(100dvh - 3.5rem);
+        width: 100vw;
     }
 </style>

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -345,7 +345,7 @@
 
     .layer-background {
         padding-top: $spacer-5;
-        height: 100dvh;
+        height: calc(100dvh - 3.5rem);
         background-color: $white;
     }
 
@@ -428,13 +428,12 @@
     }
 
     .darken-background {
-        width: 100vw;
-        height: calc(100% - 3.5rem);
         display: flex;
         flex-direction: column;
         padding-top: $spacer-5;
         align-items: center;
         justify-content: flex-start;
+        height: 100%;
 
         @include media-breakpoint-up(lg) {
             padding-top: 0;

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -347,7 +347,7 @@
 
     .layer-background {
         padding-top: $spacer-5;
-        height: calc(100dvh - 3.5rem);
+        height: calc(100dvh - $nav-bar-height);
         background-color: $white;
     }
 
@@ -466,7 +466,7 @@
         @include media-breakpoint-up(lg) {
             display: flex;
             background-color: $white;
-            height: calc(100dvh - 3.5rem);
+            height: calc(100dvh - $nav-bar-height);
             box-shadow: $box-shadow-right;
         }
     }


### PR DESCRIPTION
The height of the preview pop-up and layer-pop-up (when empty) should now not be more than one screen height.