### PR TITLE
CXC-456 adjust save draft fail safes

### DIFF
--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -8,7 +8,6 @@
     let goingBackPopUpShow = ref(false);
     let lockAspectRatio = ref(false);
     let editor = ref(null);
-    let userDidSomething = ref(false);
     let refreshCount = ref(0);
     let intersectionObserver;
     let popUpText = ref('');
@@ -21,6 +20,10 @@
 
     const redoEmpty = computed(() => {
         return comicStore.comic.getPage(0).getStrip(0).panels[activePanelIndex.value].cantRedo;
+    });
+
+    const userDidSomething = computed(() => {
+        return comicStore.userDidSomething;
     });
 
     definePageMeta({
@@ -88,6 +91,7 @@
     }
 
     function discardComic() {
+        comicStore.setUserDidSomething(false);
         return reloadNuxtApp({
             path: '/',
             ttl: 1000,
@@ -114,6 +118,7 @@
                 popUpText.value = 'Do you want to save your current comic as a draft?';
             }
         } else {
+            comicStore.setUserDidSomething(false);
             return reloadNuxtApp({
                 path: '/',
                 ttl: 1000,
@@ -143,7 +148,7 @@
 
     watch(
         () => comic.getPage(0).getStrip(0).getPanel(0).elements,
-        () => (userDidSomething.value = true),
+        () => comicStore.setUserDidSomething(true),
         { deep: true }
     );
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -254,7 +254,7 @@
     .accent-btn {
         bottom: $spacer-6;
         transform: translateX(5%);
-        z-index: 99999;
+        z-index: 999;
     }
 
     .draft-container {

--- a/stores/useComicStore.js
+++ b/stores/useComicStore.js
@@ -17,6 +17,7 @@ export const useComicStore = defineStore('comic', () => {
     let comingBackAfterSaving = ref(new Boolean(false));
 
     const draft = ref(null);
+    const userDidSomething = ref(false);
 
     function getComingBackAfterSaving() {
         if (typeof comingBackAfterSaving.value === 'string') {
@@ -28,6 +29,10 @@ export const useComicStore = defineStore('comic', () => {
 
     function setComingBackAfterSaving(bool) {
         comingBackAfterSaving.value = bool;
+    }
+
+    function setUserDidSomething(value) {
+        userDidSomething.value = value;
     }
 
     function saveDraft(json) {
@@ -169,8 +174,10 @@ export const useComicStore = defineStore('comic', () => {
     return {
         comic,
         bus,
+        userDidSomething,
         getComingBackAfterSaving,
         setComingBackAfterSaving,
+        setUserDidSomething,
         getDraft,
         saveDraft,
         deleteDraft,


### PR DESCRIPTION
I moved the userdidsomething to the store so it can be tracked across pages.
This should cover the cases when you 
- make changes in the editor
- go to the export page
- come back and try to leave the editor via the arrow in the nav (pop up will appear)

It is still possible to manually refresh the browser in that scenario though,
However, because this would then be an intentional behavior from the user in my opinion that's okay (couldn't find a solution for that).
